### PR TITLE
Fix crashes and on Windows with files across multiple drives/paths

### DIFF
--- a/ctrl.py
+++ b/ctrl.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import os.path
 import sys
 import time
 import threading
@@ -835,26 +836,26 @@ class ctrlAction(QThread):
             
         if self.currentBoard=="microbit":
             if str(filename).find("./")>=0:
-                aline="exec(open('%s').read(),globals())"%str(filename[2:])
+                aline="exec(open('%s').read(),globals())"%str(os.path.split(filename)[1])
             else:
-                aline="exec(open('%s').read(),globals())"%str(filename)
+                aline="exec(open('%s').read(),globals())"%str(os.path.split(filename)[1])
             for i in aline:
                 self.ctrltouartQueue.put("uitouart:::%s"%i)
                 time.sleep(0.001)
             self.ctrltouartQueue.put("exec_:::\r")
         else:
-            self.ctrltouartQueue.put("exec_:::exec(open(\'%s\').read(),globals())\r\n"%str(filename))
+            self.ctrltouartQueue.put("exec_:::exec(open(\'%s\').read(),globals())\r\n"%str(os.path.split(filename)[1]))
 
     def loadFile(self,filename):
         self.loadFileBool=True
         self.loadFileMsg=""
         if self.currentBoard=="microbit":
-            aline="print(open('%s','r').read())\r"%str(filename[2:])
+            aline="print(open('%s','r').read())\r"%str(os.path.split(filename)[1])
             for i in aline:
                 self.ctrltouartQueue.put("ctrltouart:::%s"%i)
                 time.sleep(0.001)
         else:
-            self.ctrltouartQueue.put("ctrltouart:::print(open(\'%s\',\'rU\').read())\r\n"%str(filename))
+            self.ctrltouartQueue.put("ctrltouart:::print(open(\'%s\',\'rU\').read())\r\n"%str(os.path.split(filename)[1]))
 
         startTime=time.time()
         while 1:
@@ -954,7 +955,7 @@ class ctrlAction(QThread):
                 return
             afile=self.dropDownFileName
         #elif filename.find(":")<0:
-        elif filename.find(rootDirectoryPath)<0:
+        elif filename.find(rootDirectoryPath)<0 and os.path.isabs(filename) == False:
             fileHandle=open(currentTempPath+filename,'rbU')
         else:
             myfile=open(currentTempPath+"/"+str(filename.split("/")[-1]),"w",encoding='UTF-8')
@@ -998,7 +999,7 @@ class ctrlAction(QThread):
                 self.ctrltouartQueue.put("ctrltouart:::%s"%i)
                 time.sleep(0.001)
         else:
-            self.ctrltouartQueue.put("ctrltouart:::myfile=open(\'%s\',\'w\')\r\n"%str(afile))
+            self.ctrltouartQueue.put("ctrltouart:::myfile=open(\'%s\',\'w\')\r\n"%str(os.path.split(afile)[1]))
         
         startTime=time.time()
         while 1:

--- a/uPyCraft.py
+++ b/uPyCraft.py
@@ -12,6 +12,7 @@ import sys
 import math
 import json
 import os
+import os.path
 import Esp
 import shutil
 import webbrowser
@@ -1472,7 +1473,7 @@ class MainWidget(QMainWindow):
             return False
 
         #if str(self.fileName).find(":")>=0:
-        if str(self.fileName).find(rootDirectoryPath)>=0:
+        if os.path.isabs(self.fileName):
             afile=self.fileName
         else:
             afile=self.fileName


### PR DESCRIPTION
Fantastic IDE, thank you! :)

I have fixed some bugs found on Windows when working across different drives and paths.  The program assumes the working directory will be on the same drive etc which makes the DownLoadAndRun functionality break (silently).

I have fixed this with a few small changes and it now works OK for me.  After fixing this I found a few similar issues with the ctrl.py file where it had to strip off the drive letter properly otherwise it sent D:/ to micropython in run commands etc which failed.

These changes should work across *nix and Windows but I have only tested them on Windows.

Original error with prints on the input paths to show why it was breaking, with 'z' being the username:
pcOpenFile:D:/ds18b20test.py
convert D:/ds18b20test.py
0
ds18b20test.py
D:/ds18b20test.py
cmd=uitouart:::
Traceback (most recent call last):
  File "C:\gitsrc\uPyCraft_src\uPyCraft.py", line 1492, in slotDownloadFileAndRun
    if self.slotDownloadFile():
  File "C:\gitsrc\uPyCraft_src\uPyCraft.py", line 1479, in slotDownloadFile
    myfile=open(str(rootDirectoryPath+afile[1:]),'w',encoding='utf-8')
OSError: [Errno 22] Invalid argument: 'C:/Users/z:/ds18b20test.py'
-1